### PR TITLE
Added 64bit integer interpretation to hex inspector

### DIFF
--- a/hex_inspector.py
+++ b/hex_inspector.py
@@ -150,6 +150,16 @@ class HexInspectorCommand(sublime_plugin.WindowCommand):
                 "dword", "--",
                 "longint", "--"
             ) + nl
+        if bytes64 is not None:
+            i_buffer += item_dec * 2 % (
+                "qword", unpack(endian + "Q", unhexlify(bytes64))[0],
+                "longlongint", unpack(endian + "q", unhexlify(bytes64))[0]
+            ) + nl
+        else:
+            i_buffer += item_str * 2 % (
+                "qword", "--",
+                "longlongint", "--"
+            ) + nl
         if bytes32 is not None:
             s_float = unpack(endian + "f", unhexlify(bytes32))[0]
             if math.isnan(s_float):

--- a/hex_viewer.sublime-settings
+++ b/hex_viewer.sublime-settings
@@ -90,17 +90,17 @@
     "auto_open_patterns" : ["*.bin", "*.pyc"],
 
     // Inspector format strings: ints and unsigned ints
-    "inspector_integer_format": "%-12s:  %-14d",
+    "inspector_integer_format": "%-12s:  %-22d",
 
     // Inspector format strings: floating point decimals
-    "insepctor_float_format": "%-12s:  %-14e",
+    "insepctor_float_format": "%-12s:  %-22e",
 
     // Inspector format strings: double floating point decimal strings
-    "inspector_double_format": "%-12s:  %-14e",
+    "inspector_double_format": "%-12s:  %-22e",
 
     // Inspector format strings: "NAN" and not enough bytes to show numbers "--"
-    "inspector_missing/bad_format": "%-12s:  %-14s",
+    "inspector_missing/bad_format": "%-12s:  %-22s",
 
     // Binary number formatting
-    "inspector_binary_format": "%-12s:  %-14s"
+    "inspector_binary_format": "%-12s:  %-22s"
 }


### PR DESCRIPTION
Some binary formats have started using 64bit fields, the HexViewer should be extended to be able to parse these.
