### PR TITLE
Fix monospace font issue

### DIFF
--- a/hex_viewer.py
+++ b/hex_viewer.py
@@ -234,7 +234,7 @@ class HexViewerCommand(sublime_plugin.WindowCommand):
         file_name = None
         if self.view is not None:
             # Get font settings
-            self.font = hv_settings('custom_font', 'None')
+            self.font = hv_settings('custom_font', 'none')
             self.font_size = hv_settings('custom_font_size', 0)
 
             # Get file name


### PR DESCRIPTION
When I don't have a settings file, HexViewer doesn't show a monospaced font even though my default sublime text font is monospaced.

It looks like it is a case issue on line 237 of hex_viewer.py and line 300 of hex_viewer.py.

This is probably related to issues #19, #7, #8, #10, and #23